### PR TITLE
fix ldif syntax and add idnsTemplateAttribute

### DIFF
--- a/doc/schema.ldif
+++ b/doc/schema.ldif
@@ -362,8 +362,15 @@ attributeTypes: ( 2.16.840.1.113730.3.8.5.31
  NAME 'idnsServerId'
  DESC 'DNS server identifier'
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
- EQUALITY caseIgnoreMatch
+ EQUALITY caseIgnoreMatch 
  SINGLE-VALUE )
+#
+attributeTypes: ( 2.16.840.1.113730.3.8.5.29 
+ NAME 'idnsTemplateAttribute' 
+ DESC 'Template attribute for dynamic attribute generation' 
+ EQUALITY caseIgnoreIA5Match 
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 
+ X-ORIGIN 'IPA v4.4' )
 #
 attributeTypes: ( 2.16.840.1.113730.3.8.5.30 
  NAME 'idnsSubstitutionVariable' 
@@ -426,6 +433,6 @@ objectClasses: ( 2.16.840.1.113730.3.8.6.6
 objectClasses: ( 2.16.840.1.113730.3.8.6.5 
  NAME 'idnsTemplateObject' 
  DESC 'Template object for dynamic DNS attribute generation' 
- SUP top
+ SUP top 
  AUXILIARY 
  MUST ( idnsTemplateAttribute ) )


### PR DESCRIPTION
schema.ldif lost some white space in the line end.
schema.ldif lost the idnsTemplateAttribute definitition
