### PR TITLE
Log when pointers are different

### DIFF
--- a/src/ldap_driver.c
+++ b/src/ldap_driver.c
@@ -1063,6 +1063,7 @@ dyndb_init(isc_mem_t *mctx, const char *name, const char *parameters,
 		isc_lib_register();
 		isc_log_setcontext(dctx->lctx);
 		dns_log_setcontext(dctx->lctx);
+		log_debug(5, "registering library from dynamic ldap driver, %p != %p.", dctx->refvar, &isc_bind9);
 	}
 
 	isc_hash_set_initializer(dctx->hashinit);


### PR DESCRIPTION
Log both different addresses when it is needed to register isc and dns libraries and set their log context.