### PR TITLE
spec: remove unnecessary bind-pkcs11 dependency

### DIFF
--- a/contrib/bind-dyndb-ldap.spec
+++ b/contrib/bind-dyndb-ldap.spec
@@ -12,13 +12,13 @@ Source0:        https://releases.pagure.org/%{name}/%{name}-%{VERSION}.tar.bz2
 Source1:        https://releases.pagure.org/%{name}/%{name}-%{VERSION}.tar.bz2.asc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  bind-devel >= 32:9.11.0-6.P2, bind-lite-devel >= 32:9.11.0-6.P2, bind-pkcs11-devel >= 32:9.11.0-6.P2
+BuildRequires:  bind-devel >= 32:9.11.0-6.P2, bind-lite-devel >= 32:9.11.0-6.P2
 BuildRequires:  krb5-devel
 BuildRequires:  openldap-devel
 BuildRequires:  libuuid-devel
 BuildRequires:  automake, autoconf, libtool
 
-Requires:       bind-pkcs11 >= 32:9.11.0-6.P2, bind-pkcs11-utils >= 32:9.11.0-6.P2
+Requires:       bind >= 32:9.11.0-6.P2
 
 %description
 This package provides an LDAP back-end plug-in for BIND. It features
@@ -114,6 +114,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Apr 07 2017 Tomas Krizek <tkrizek@redhat.com>
+- Removed unnecessary bind-pkcs11 dependency
+
 * Mon Mar 13 2017 Tomas Krizek <tkrizek@redhat.com>
 - Fixed sed script regex error
 - Re-synced specfile with fedora


### PR DESCRIPTION
The bind-pkcs11 dependency was originally introduced in Fedora
specfile in 2014 to help with ipa-server-upgrade. This was a
temporary workaround. Since Fedora life cycle is 13 months and
this change happened more than two years ago, it is safe to
remove the workaround.

bind-dyndb-ldap does not actually depend on bind-pkcs11, although it
is a dependency that is enforced by freeipa.