### PR TITLE
settings: skip unconfigured values

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -33,9 +33,7 @@ static const setting_t settings_default[] = {
 	{ "uri",			no_default_string		}, /* User have to set this */
 	{ "connections",		default_uint(2)			},
 	{ "reconnect_interval",		default_uint(60)		},
-	{ "zone_refresh",		default_string("")		}, /* No longer supported */
 	{ "timeout",			default_uint(10)		},
-	{ "cache_ttl",			default_string("")		}, /* No longer supported */
 	{ "timeout",			default_uint(10)		},
 	{ "base",	 		no_default_string		}, /* User have to set this */
 	{ "auth_method",		default_string("none")		},
@@ -49,7 +47,6 @@ static const setting_t settings_default[] = {
 	{ "sasl_password",		default_string("")		},
 	{ "krb5_keytab",		default_string("")		},
 	{ "fake_mname",			default_string("")		},
-	{ "psearch",			default_string("")		}, /* No longer supported */
 	{ "ldap_hostname",		default_string("")		},
 	{ "sync_ptr",			default_boolean(ISC_FALSE)	},
 	{ "dyn_update",			default_boolean(ISC_FALSE)	},
@@ -60,7 +57,6 @@ static const setting_t settings_default[] = {
 	 * SSU table defined by empty string contains no rules =>
 	 * dns_ssutable_checkrules() will return deny. */
 	{ "update_policy",		default_string("")		},
-	{ "serial_autoincrement",	default_string("")		},
 	{ "verbose_checks",		default_boolean(ISC_FALSE)	},
 	{ "directory",			default_string("")		},
 	{ "server_id",			default_string("")		},

--- a/src/settings.c
+++ b/src/settings.c
@@ -597,8 +597,11 @@ settings_set_fill(const cfg_obj_t *config, settings_set_t *set)
 	     setting++) {
 		cfg_value = NULL;
 		result = cfg_map_get(config, setting->name, &cfg_value);
-		if (result == ISC_R_NOTFOUND)
-			continue; /* setting not configured in map */
+		if (result == ISC_R_NOTFOUND) {
+			/* setting not configured in map */
+			result = ISC_R_SUCCESS;
+			continue;
+		}
 		else if (result != ISC_R_SUCCESS)
 			goto cleanup;
 		if (cfg_obj_isstring(cfg_value)) {


### PR DESCRIPTION
When a value is not configured in settings map, it is skipped.
If it is the last processed value, the result of ISC_R_NOTFOUND
would cause the cleanup section of the function fail. Since
unconfigured values are allowed and expected, override the result
to ISC_R_SUCCESS in this case to prevent triggerring an error.

https://pagure.io/bind-dyndb-ldap/issue/172

---

Also removed obsolete options from the map.