### PR TITLE
Update to BIND 9.11.1

### DIFF
--- a/contrib/bind-dyndb-ldap.spec
+++ b/contrib/bind-dyndb-ldap.spec
@@ -1,5 +1,7 @@
 %define VERSION %{version}
 
+%define bind_version 32:9.11.1-1.P1
+
 Name:           bind-dyndb-ldap
 Version:        11.1
 Release:        0%{?dist}
@@ -12,13 +14,13 @@ Source0:        https://releases.pagure.org/%{name}/%{name}-%{VERSION}.tar.bz2
 Source1:        https://releases.pagure.org/%{name}/%{name}-%{VERSION}.tar.bz2.asc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  bind-devel >= 32:9.11.0-6.P2, bind-lite-devel >= 32:9.11.0-6.P2
+BuildRequires:  bind-devel >= %{bind_version}, bind-lite-devel >= %{bind_version}
 BuildRequires:  krb5-devel
 BuildRequires:  openldap-devel
 BuildRequires:  libuuid-devel
 BuildRequires:  automake, autoconf, libtool
 
-Requires:       bind >= 32:9.11.0-6.P2
+Requires:       bind >= %{bind_version}
 
 %description
 This package provides an LDAP back-end plug-in for BIND. It features
@@ -114,6 +116,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Tue Jun 27 2017 Tomas Krizek <tkrizek@redhat.com>
+- Bump BIND version
+
 * Fri Apr 07 2017 Tomas Krizek <tkrizek@redhat.com>
 - Removed unnecessary bind-pkcs11 dependency
 

--- a/src/ldap_driver.c
+++ b/src/ldap_driver.c
@@ -867,7 +867,8 @@ static dns_dbmethods_t ldapdb_methods = {
 	findext,
 	setcachestats,
 	hashsize,
-	nodefullname
+	nodefullname,
+	NULL, // getsize method not implemented (related BZ1353563)
 };
 
 isc_result_t ATTR_NONNULLS


### PR DESCRIPTION
Bump BIND version to 9.11.1

---

Add empty callback for getsize

BIND introduced getsize method in db.h. This is related to
CVE-2016-6170 and allows to set restriction of zone size limit.